### PR TITLE
fix: apply patches for functional builds

### DIFF
--- a/arch/x86/include/asm/pvm_para.h
+++ b/arch/x86/include/asm/pvm_para.h
@@ -5,6 +5,10 @@
 #include <linux/init.h>
 #include <uapi/asm/pvm_para.h>
 
+typedef unsigned long long u64;
+typedef unsigned int u32;
+typedef unsigned short u16;
+
 #ifndef __ASSEMBLY__
 typedef void (*idtentry_t)(struct pt_regs *regs);
 

--- a/arch/x86/include/uapi/asm/pvm_para.h
+++ b/arch/x86/include/uapi/asm/pvm_para.h
@@ -4,6 +4,10 @@
 
 #include <linux/const.h>
 
+typedef unsigned long long u64;
+typedef unsigned int u32;
+typedef unsigned short u16;
+
 /*
  * The CPUID instruction in PVM guest can't be trapped and emulated,
  * so PVM guest should use the following two instructions instead:

--- a/arch/x86/kernel/setup.c
+++ b/arch/x86/kernel/setup.c
@@ -718,6 +718,27 @@ static void __init x86_report_nx(void)
 	}
 }
 
+#ifdef CONFIG_X86_64
+static void __init x86_reserve_vmalloc_range(void)
+{
+       static struct vm_struct pvm;
+       unsigned long size = 32UL << 39;
+
+       if (pgtable_l5_enabled())
+               size = 32UL << 48;
+
+       pvm.addr = (void *)(VMALLOC_END + 1 - size);
+       pvm.size = size;
+       pvm.flags = VM_ALLOC | VM_NO_GUARD;
+
+       vm_area_add_early(&pvm);
+}
+#else
+static void __init x86_reserve_vmalloc_range(void)
+{
+}
+#endif
+
 /*
  * Determine if we were loaded by an EFI loader.  If so, then we have also been
  * passed the efi memmap, systab, etc., so we should use these data structures
@@ -960,6 +981,7 @@ void __init setup_arch(char **cmdline_p)
 	 * defined and before each memory section base is used.
 	 */
 	kernel_randomize_memory();
+	x86_reserve_vmalloc_range();
 
 #ifdef CONFIG_X86_32
 	/* max_low_pfn get updated here */

--- a/arch/x86/kvm/pvm/host_mmu.c
+++ b/arch/x86/kvm/pvm/host_mmu.c
@@ -51,9 +51,8 @@ static int __init guest_address_space_init(void)
 		pml4_index_start = L4_PT_INDEX(PVM_GUEST_MAPPING_START);
 		pml4_index_end = L4_PT_INDEX(RAW_CPU_ENTRY_AREA_BASE);
 
-		pvm_va_range = get_vm_area_align(DEFAULT_RANGE_L5_SIZE, PT_L5_SIZE,
-						 VM_ALLOC|VM_NO_GUARD);
-		if (!pvm_va_range) {
+       pvm_va_range = find_vm_area((void *)(VMALLOC_END + 1 - DEFAULT_RANGE_L5_SIZE));
+       if (!pvm_va_range || pvm_va_range->size != DEFAULT_RANGE_L5_SIZE) {
 			pml5_index_start = 0x1ff;
 			pml5_index_end = 0x1ff;
 		} else {
@@ -62,9 +61,8 @@ static int __init guest_address_space_init(void)
 						     (u64)pvm_va_range->size);
 		}
 	} else {
-		pvm_va_range = get_vm_area_align(DEFAULT_RANGE_L4_SIZE, PT_L4_SIZE,
-						 VM_ALLOC|VM_NO_GUARD);
-		if (!pvm_va_range)
+		pvm_va_range = find_vm_area((void *)(VMALLOC_END + 1 - DEFAULT_RANGE_L4_SIZE));
+		if (!pvm_va_range || pvm_va_range->size != DEFAULT_RANGE_L4_SIZE)
 			return -1;
 
 		pml4_index_start = L4_PT_INDEX((u64)pvm_va_range->addr);
@@ -133,8 +131,6 @@ int __init host_mmu_init(void)
 
 void host_mmu_destroy(void)
 {
-	if (pvm_va_range)
-		free_vm_area(pvm_va_range);
 	if (host_mmu_root_pgd)
 		free_page((unsigned long)(void *)host_mmu_root_pgd);
 	if (host_mmu_la57_top_p4d)

--- a/arch/x86/kvm/pvm/pvm.c
+++ b/arch/x86/kvm/pvm/pvm.c
@@ -754,12 +754,15 @@ static bool check_switch_cr3(struct vcpu_pvm *pvm, u64 switch_host_cr3)
 		return false;
 	if (!VALID_PAGE(root))
 		return false;
-	if (host_pcid_owner(switch_host_cr3 & X86_CR3_PCID_MASK) != pvm)
-		return false;
-	if (host_pcid_root(switch_host_cr3 & X86_CR3_PCID_MASK) != root)
-		return false;
 	if (root != (switch_host_cr3 & CR3_ADDR_MASK))
 		return false;
+
+	if (static_cpu_has(X86_FEATURE_PCID)) {
+		if (host_pcid_owner(switch_host_cr3 & X86_CR3_PCID_MASK) != pvm)
+			return false;
+		if (host_pcid_root(switch_host_cr3 & X86_CR3_PCID_MASK) != root)
+			return false;
+	}
 
 	return true;
 }
@@ -785,24 +788,30 @@ static void pvm_pgtbl_preload_for_guest_with_host_pcid(struct vcpu_pvm *pvm, u64
 	return;
 }
 
-static void pvm_set_host_cr3_for_guest_with_host_pcid(struct vcpu_pvm *pvm)
+static void pvm_set_host_cr3_for_guest(struct vcpu_pvm *pvm)
 {
-	u64 root_hpa = pvm->vcpu.arch.mmu->root.hpa;
-	bool flush = false;
-	u32 host_pcid = host_pcid_get(pvm, root_hpa, &flush);
-	u64 hw_cr3 = root_hpa | host_pcid;
+	u64 hw_cr3 = __sme_set(pvm->vcpu.arch.mmu->root.hpa);
+	u64 enter_hw_cr3 = hw_cr3;
 	u64 switch_host_cr3;
 
-	if (!flush)
-		hw_cr3 |= CR3_NOFLUSH;
-	this_cpu_write(cpu_tss_rw.tss_ex.enter_cr3, hw_cr3);
+	if (static_cpu_has(X86_FEATURE_PCID)) {
+		bool flush = false;
+		u32 host_pcid = host_pcid_get(pvm, hw_cr3, &flush);
+
+		enter_hw_cr3 |= host_pcid;
+		if (!flush)
+			enter_hw_cr3 |= CR3_NOFLUSH;
+		hw_cr3 |= host_pcid | CR3_NOFLUSH;
+	}
+
+	this_cpu_write(cpu_tss_rw.tss_ex.enter_cr3, enter_hw_cr3);
 
 	if (is_smod(pvm)) {
-		this_cpu_write(cpu_tss_rw.tss_ex.smod_cr3, hw_cr3 | CR3_NOFLUSH);
+		this_cpu_write(cpu_tss_rw.tss_ex.smod_cr3, hw_cr3);
 		switch_host_cr3 = this_cpu_read(cpu_tss_rw.tss_ex.umod_cr3);
 		pvm_pgtbl_preload_for_guest_with_host_pcid(pvm, &switch_host_cr3);
 	} else {
-		this_cpu_write(cpu_tss_rw.tss_ex.umod_cr3, hw_cr3 | CR3_NOFLUSH);
+		this_cpu_write(cpu_tss_rw.tss_ex.umod_cr3, hw_cr3);
 		switch_host_cr3 = this_cpu_read(cpu_tss_rw.tss_ex.smod_cr3);
 	}
 
@@ -810,30 +819,6 @@ static void pvm_set_host_cr3_for_guest_with_host_pcid(struct vcpu_pvm *pvm)
 		pvm->switch_flags &= ~SWITCH_FLAGS_NO_DS_CR3;
 	else
 		pvm->switch_flags |= SWITCH_FLAGS_NO_DS_CR3;
-}
-
-static void pvm_set_host_cr3_for_guest_without_host_pcid(struct vcpu_pvm *pvm)
-{
-	u64 root_hpa = pvm->vcpu.arch.mmu->root.hpa;
-	u64 switch_root = 0;
-	u64 prev_root_hpa = pvm->vcpu.arch.mmu->prev_roots[0].hpa;
-
-	if (VALID_PAGE(prev_root_hpa) &&
-	    pvm->vcpu.arch.mmu->prev_roots[0].pgd == pvm->msr_switch_cr3) {
-		switch_root = prev_root_hpa;
-		pvm->switch_flags &= ~SWITCH_FLAGS_NO_DS_CR3;
-	} else {
-		pvm->switch_flags |= SWITCH_FLAGS_NO_DS_CR3;
-	}
-
-	this_cpu_write(cpu_tss_rw.tss_ex.enter_cr3, root_hpa);
-	if (is_smod(pvm)) {
-		this_cpu_write(cpu_tss_rw.tss_ex.smod_cr3, root_hpa);
-		this_cpu_write(cpu_tss_rw.tss_ex.umod_cr3, switch_root);
-	} else {
-		this_cpu_write(cpu_tss_rw.tss_ex.umod_cr3, root_hpa);
-		this_cpu_write(cpu_tss_rw.tss_ex.smod_cr3, switch_root);
-	}
 }
 
 static void pvm_set_host_cr3_for_hypervisor(struct vcpu_pvm *pvm)
@@ -854,11 +839,7 @@ static void pvm_set_host_cr3_for_hypervisor(struct vcpu_pvm *pvm)
 static void pvm_set_host_cr3(struct vcpu_pvm *pvm)
 {
 	pvm_set_host_cr3_for_hypervisor(pvm);
-
-	if (static_cpu_has(X86_FEATURE_PCID))
-		pvm_set_host_cr3_for_guest_with_host_pcid(pvm);
-	else
-		pvm_set_host_cr3_for_guest_without_host_pcid(pvm);
+	pvm_set_host_cr3_for_guest(pvm);
 }
 
 static void pvm_load_mmu_pgd(struct kvm_vcpu *vcpu, hpa_t root_hpa,

--- a/certs/extract-cert.c
+++ b/certs/extract-cert.c
@@ -21,14 +21,17 @@
 #include <openssl/bio.h>
 #include <openssl/pem.h>
 #include <openssl/err.h>
-#include <openssl/engine.h>
-
-/*
- * OpenSSL 3.0 deprecates the OpenSSL's ENGINE API.
- *
- * Remove this if/when that API is no longer used
- */
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#if OPENSSL_VERSION_MAJOR >= 3
+# define USE_PKCS11_PROVIDER
+# include <openssl/provider.h>
+# include <openssl/store.h>
+#else
+# if !defined(OPENSSL_NO_ENGINE) && !defined(OPENSSL_NO_DEPRECATED_3_0)
+#  define USE_PKCS11_ENGINE
+#  include <openssl/engine.h>
+# endif
+#endif
+#include "ssl-common.h"
 
 #define PKEY_ID_PKCS7 2
 
@@ -39,41 +42,6 @@ void format(void)
 		"Usage: extract-cert <source> <dest>\n");
 	exit(2);
 }
-
-static void display_openssl_errors(int l)
-{
-	const char *file;
-	char buf[120];
-	int e, line;
-
-	if (ERR_peek_error() == 0)
-		return;
-	fprintf(stderr, "At main.c:%d:\n", l);
-
-	while ((e = ERR_get_error_line(&file, &line))) {
-		ERR_error_string(e, buf);
-		fprintf(stderr, "- SSL %s: %s:%d\n", buf, file, line);
-	}
-}
-
-static void drain_openssl_errors(void)
-{
-	const char *file;
-	int line;
-
-	if (ERR_peek_error() == 0)
-		return;
-	while (ERR_get_error_line(&file, &line)) {}
-}
-
-#define ERR(cond, fmt, ...)				\
-	do {						\
-		bool __cond = (cond);			\
-		display_openssl_errors(__LINE__);	\
-		if (__cond) {				\
-			err(1, fmt, ## __VA_ARGS__);	\
-		}					\
-	} while(0)
 
 static const char *key_pass;
 static BIO *wb;
@@ -92,6 +60,66 @@ static void write_cert(X509 *x509)
 	ERR(!i2d_X509_bio(wb, x509), "%s", cert_dst);
 	if (verbose)
 		fprintf(stderr, "Extracted cert: %s\n", buf);
+}
+
+static X509 *load_cert_pkcs11(const char *cert_src)
+{
+	X509 *cert = NULL;
+#ifdef USE_PKCS11_PROVIDER
+	OSSL_STORE_CTX *store;
+
+	if (!OSSL_PROVIDER_try_load(NULL, "pkcs11", true))
+		ERR(1, "OSSL_PROVIDER_try_load(pkcs11)");
+	if (!OSSL_PROVIDER_try_load(NULL, "default", true))
+		ERR(1, "OSSL_PROVIDER_try_load(default)");
+
+	store = OSSL_STORE_open(cert_src, NULL, NULL, NULL, NULL);
+	ERR(!store, "OSSL_STORE_open");
+
+	while (!OSSL_STORE_eof(store)) {
+		OSSL_STORE_INFO *info = OSSL_STORE_load(store);
+
+		if (!info) {
+			drain_openssl_errors(__LINE__, 0);
+			continue;
+		}
+		if (OSSL_STORE_INFO_get_type(info) == OSSL_STORE_INFO_CERT) {
+			cert = OSSL_STORE_INFO_get1_CERT(info);
+			ERR(!cert, "OSSL_STORE_INFO_get1_CERT");
+		}
+		OSSL_STORE_INFO_free(info);
+		if (cert)
+			break;
+	}
+	OSSL_STORE_close(store);
+#elif defined(USE_PKCS11_ENGINE)
+		ENGINE *e;
+		struct {
+			const char *cert_id;
+			X509 *cert;
+		} parms;
+
+		parms.cert_id = cert_src;
+		parms.cert = NULL;
+
+		ENGINE_load_builtin_engines();
+		drain_openssl_errors(__LINE__, 1);
+		e = ENGINE_by_id("pkcs11");
+		ERR(!e, "Load PKCS#11 ENGINE");
+		if (ENGINE_init(e))
+			drain_openssl_errors(__LINE__, 1);
+		else
+			ERR(1, "ENGINE_init");
+		if (key_pass)
+			ERR(!ENGINE_ctrl_cmd_string(e, "PIN", key_pass, 0), "Set PKCS#11 PIN");
+		ENGINE_ctrl_cmd(e, "LOAD_CERT_CTRL", 0, &parms, NULL, 1);
+		ERR(!parms.cert, "Get X.509 from PKCS#11");
+		cert = parms.cert;
+#else
+		fprintf(stderr, "no pkcs11 engine/provider available\n");
+		exit(1);
+#endif
+	return cert;
 }
 
 int main(int argc, char **argv)
@@ -122,28 +150,10 @@ int main(int argc, char **argv)
 		fclose(f);
 		exit(0);
 	} else if (!strncmp(cert_src, "pkcs11:", 7)) {
-		ENGINE *e;
-		struct {
-			const char *cert_id;
-			X509 *cert;
-		} parms;
+		X509 *cert = load_cert_pkcs11(cert_src);
 
-		parms.cert_id = cert_src;
-		parms.cert = NULL;
-
-		ENGINE_load_builtin_engines();
-		drain_openssl_errors();
-		e = ENGINE_by_id("pkcs11");
-		ERR(!e, "Load PKCS#11 ENGINE");
-		if (ENGINE_init(e))
-			drain_openssl_errors();
-		else
-			ERR(1, "ENGINE_init");
-		if (key_pass)
-			ERR(!ENGINE_ctrl_cmd_string(e, "PIN", key_pass, 0), "Set PKCS#11 PIN");
-		ENGINE_ctrl_cmd(e, "LOAD_CERT_CTRL", 0, &parms, NULL, 1);
-		ERR(!parms.cert, "Get X.509 from PKCS#11");
-		write_cert(parms.cert);
+		ERR(!cert, "load_cert_pkcs11 failed");
+		write_cert(cert);
 	} else {
 		BIO *b;
 		X509 *x509;

--- a/certs/ssl-common.h
+++ b/certs/ssl-common.h
@@ -1,0 +1,32 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+/*
+ * SSL helper functions shared by sign-file and extract-cert.
+ */
+
+static void drain_openssl_errors(int l, int silent)
+{
+	const char *file;
+	char buf[120];
+	int e, line;
+
+	if (ERR_peek_error() == 0)
+		return;
+	if (!silent)
+		fprintf(stderr, "At main.c:%d:\n", l);
+
+	while ((e = ERR_peek_error_line(&file, &line))) {
+		ERR_error_string(e, buf);
+		if (!silent)
+			fprintf(stderr, "- SSL %s: %s:%d\n", buf, file, line);
+		ERR_get_error();
+	}
+}
+
+#define ERR(cond, fmt, ...)				\
+	do {						\
+		bool __cond = (cond);			\
+		drain_openssl_errors(__LINE__, 0);	\
+		if (__cond) {				\
+			errx(1, fmt, ## __VA_ARGS__);	\
+		}					\
+	} while (0)

--- a/mm/vmalloc.c
+++ b/mm/vmalloc.c
@@ -2681,6 +2681,8 @@ struct vm_struct *find_vm_area(const void *addr)
 	return va->vm;
 }
 
+EXPORT_SYMBOL_GPL(find_vm_area);
+
 /**
  * remove_vm_area - find and remove a continuous kernel virtual area
  * @addr:	    base address

--- a/scripts/package/kernel.spec
+++ b/scripts/package/kernel.spec
@@ -27,7 +27,7 @@ The Linux Kernel, the operating system core itself
 %package headers
 Summary: Header files for the Linux kernel for use by glibc
 Group: Development/System
-Obsoletes: kernel-headers
+Obsoletes: kernel-headers < %{version}
 Provides: kernel-headers = %{version}
 %description headers
 Kernel-headers includes the C header files that specify the interface
@@ -77,11 +77,15 @@ rm -rf %{buildroot}
 
 %post
 if [ -x /sbin/installkernel -a -r /boot/vmlinuz-%{KERNELRELEASE} -a -r /boot/System.map-%{KERNELRELEASE} ]; then
+if [ $(rpm -qf /sbin/installkernel --queryformat "%{n}") = systemd-udev ];then
+/sbin/installkernel %{KERNELRELEASE} /boot/vmlinuz-%{KERNELRELEASE} /boot/System.map-%{KERNELRELEASE}
+else
 cp /boot/vmlinuz-%{KERNELRELEASE} /boot/.vmlinuz-%{KERNELRELEASE}-rpm
 cp /boot/System.map-%{KERNELRELEASE} /boot/.System.map-%{KERNELRELEASE}-rpm
 rm -f /boot/vmlinuz-%{KERNELRELEASE} /boot/System.map-%{KERNELRELEASE}
 /sbin/installkernel %{KERNELRELEASE} /boot/.vmlinuz-%{KERNELRELEASE}-rpm /boot/.System.map-%{KERNELRELEASE}-rpm
 rm -f /boot/.vmlinuz-%{KERNELRELEASE}-rpm /boot/.System.map-%{KERNELRELEASE}-rpm
+fi
 fi
 
 %preun
@@ -112,3 +116,8 @@ fi
 /usr/src/kernels/%{KERNELRELEASE}
 /lib/modules/%{KERNELRELEASE}/build
 %endif
+
+%changelog
+* %(echo "$(LC_ALL=C; date +'%a %b %d %Y') $(git config --get user.name) \
+<$(git config --get user.email)>") - %{version}-%{release}
+- Custom built Linux kernel.

--- a/scripts/sign-file.c
+++ b/scripts/sign-file.c
@@ -27,14 +27,17 @@
 #include <openssl/evp.h>
 #include <openssl/pem.h>
 #include <openssl/err.h>
-#include <openssl/engine.h>
-
-/*
- * OpenSSL 3.0 deprecates the OpenSSL's ENGINE API.
- *
- * Remove this if/when that API is no longer used
- */
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#if OPENSSL_VERSION_MAJOR >= 3
+# define USE_PKCS11_PROVIDER
+# include <openssl/provider.h>
+# include <openssl/store.h>
+#else
+# if !defined(OPENSSL_NO_ENGINE) && !defined(OPENSSL_NO_DEPRECATED_3_0)
+#  define USE_PKCS11_ENGINE
+#  include <openssl/engine.h>
+# endif
+#endif
+#include "ssl-common.h"
 
 /*
  * Use CMS if we have openssl-1.0.0 or newer available - otherwise we have to
@@ -83,41 +86,6 @@ void format(void)
 	exit(2);
 }
 
-static void display_openssl_errors(int l)
-{
-	const char *file;
-	char buf[120];
-	int e, line;
-
-	if (ERR_peek_error() == 0)
-		return;
-	fprintf(stderr, "At main.c:%d:\n", l);
-
-	while ((e = ERR_get_error_line(&file, &line))) {
-		ERR_error_string(e, buf);
-		fprintf(stderr, "- SSL %s: %s:%d\n", buf, file, line);
-	}
-}
-
-static void drain_openssl_errors(void)
-{
-	const char *file;
-	int line;
-
-	if (ERR_peek_error() == 0)
-		return;
-	while (ERR_get_error_line(&file, &line)) {}
-}
-
-#define ERR(cond, fmt, ...)				\
-	do {						\
-		bool __cond = (cond);			\
-		display_openssl_errors(__LINE__);	\
-		if (__cond) {				\
-			errx(1, fmt, ## __VA_ARGS__);	\
-		}					\
-	} while(0)
-
 static const char *key_pass;
 
 static int pem_pw_cb(char *buf, int len, int w, void *v)
@@ -139,28 +107,64 @@ static int pem_pw_cb(char *buf, int len, int w, void *v)
 	return pwlen;
 }
 
+static EVP_PKEY *read_private_key_pkcs11(const char *private_key_name)
+{
+	EVP_PKEY *private_key = NULL;
+#ifdef USE_PKCS11_PROVIDER
+	OSSL_STORE_CTX *store;
+
+	if (!OSSL_PROVIDER_try_load(NULL, "pkcs11", true))
+		ERR(1, "OSSL_PROVIDER_try_load(pkcs11)");
+	if (!OSSL_PROVIDER_try_load(NULL, "default", true))
+		ERR(1, "OSSL_PROVIDER_try_load(default)");
+
+	store = OSSL_STORE_open(private_key_name, NULL, NULL, NULL, NULL);
+	ERR(!store, "OSSL_STORE_open");
+
+	while (!OSSL_STORE_eof(store)) {
+		OSSL_STORE_INFO *info = OSSL_STORE_load(store);
+
+		if (!info) {
+			drain_openssl_errors(__LINE__, 0);
+			continue;
+		}
+		if (OSSL_STORE_INFO_get_type(info) == OSSL_STORE_INFO_PKEY) {
+			private_key = OSSL_STORE_INFO_get1_PKEY(info);
+			ERR(!private_key, "OSSL_STORE_INFO_get1_PKEY");
+		}
+		OSSL_STORE_INFO_free(info);
+		if (private_key)
+			break;
+	}
+	OSSL_STORE_close(store);
+#elif defined(USE_PKCS11_ENGINE)
+	ENGINE *e;
+
+	ENGINE_load_builtin_engines();
+	drain_openssl_errors(__LINE__, 1);
+	e = ENGINE_by_id("pkcs11");
+	ERR(!e, "Load PKCS#11 ENGINE");
+	if (ENGINE_init(e))
+		drain_openssl_errors(__LINE__, 1);
+	else
+		ERR(1, "ENGINE_init");
+	if (key_pass)
+		ERR(!ENGINE_ctrl_cmd_string(e, "PIN", key_pass, 0), "Set PKCS#11 PIN");
+	private_key = ENGINE_load_private_key(e, private_key_name, NULL, NULL);
+	ERR(!private_key, "%s", private_key_name);
+#else
+	fprintf(stderr, "no pkcs11 engine/provider available\n");
+	exit(1);
+#endif
+	return private_key;
+}
+
 static EVP_PKEY *read_private_key(const char *private_key_name)
 {
-	EVP_PKEY *private_key;
-
 	if (!strncmp(private_key_name, "pkcs11:", 7)) {
-		ENGINE *e;
-
-		ENGINE_load_builtin_engines();
-		drain_openssl_errors();
-		e = ENGINE_by_id("pkcs11");
-		ERR(!e, "Load PKCS#11 ENGINE");
-		if (ENGINE_init(e))
-			drain_openssl_errors();
-		else
-			ERR(1, "ENGINE_init");
-		if (key_pass)
-			ERR(!ENGINE_ctrl_cmd_string(e, "PIN", key_pass, 0),
-			    "Set PKCS#11 PIN");
-		private_key = ENGINE_load_private_key(e, private_key_name,
-						      NULL, NULL);
-		ERR(!private_key, "%s", private_key_name);
+		return read_private_key_pkcs11(private_key_name);
 	} else {
+		EVP_PKEY *private_key;
 		BIO *b;
 
 		b = BIO_new_file(private_key_name, "rb");
@@ -169,9 +173,9 @@ static EVP_PKEY *read_private_key(const char *private_key_name)
 						      NULL);
 		ERR(!private_key, "%s", private_key_name);
 		BIO_free(b);
-	}
 
-	return private_key;
+		return private_key;
+	}
 }
 
 static X509 *read_x509(const char *x509_name)
@@ -306,7 +310,7 @@ int main(int argc, char **argv)
 
 		/* Digest the module data. */
 		OpenSSL_add_all_digests();
-		display_openssl_errors(__LINE__);
+		drain_openssl_errors(__LINE__, 0);
 		digest_algo = EVP_get_digestbyname(hash_algo);
 		ERR(!digest_algo, "EVP_get_digestbyname");
 

--- a/scripts/ssl-common.h
+++ b/scripts/ssl-common.h
@@ -1,0 +1,32 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+/*
+ * SSL helper functions shared by sign-file and extract-cert.
+ */
+
+static void drain_openssl_errors(int l, int silent)
+{
+	const char *file;
+	char buf[120];
+	int e, line;
+
+	if (ERR_peek_error() == 0)
+		return;
+	if (!silent)
+		fprintf(stderr, "At main.c:%d:\n", l);
+
+	while ((e = ERR_peek_error_line(&file, &line))) {
+		ERR_error_string(e, buf);
+		if (!silent)
+			fprintf(stderr, "- SSL %s: %s:%d\n", buf, file, line);
+		ERR_get_error();
+	}
+}
+
+#define ERR(cond, fmt, ...)				\
+	do {						\
+		bool __cond = (cond);			\
+		drain_openssl_errors(__LINE__, 0);	\
+		if (__cond) {				\
+			errx(1, fmt, ## __VA_ARGS__);	\
+		}					\
+	} while (0)


### PR DESCRIPTION
This PR applies patches to make building the PVM kernel easier as well as refactors the C3 switching logic to be more streamlined and less bug-prone. 